### PR TITLE
Fix bug when proto files were directly next to each other

### DIFF
--- a/protobuf_to_pydantic/plugin/field_desc_proto_to_code.py
+++ b/protobuf_to_pydantic/plugin/field_desc_proto_to_code.py
@@ -79,7 +79,7 @@ class FileDescriptorProtoToCode(BaseP2C):
             + self.config.file_name_suffix
         )
         logger.info((self._fd.name, other_fd.name, index))
-        if index != "-1":
+        if index != -1:
             module_name = "." * (len(message_path_list) - (index + 1)) + module_name
         self._add_import_code(module_name, type_str)
 


### PR DESCRIPTION
I had the case of two protofiles being directly next to each other:

protobuf/standalone.proto
protobuf/includes_standalone.proto

The resulting import came up as `from ..standalone import Standalone`, with one dot too many. Changing this from `"-1"`  to `-1` fixed it for me.

```py
>>> "-1" == -1
False
```