### PR TITLE
Fix relative includes in case the files are next to each other

### DIFF
--- a/protobuf_to_pydantic/plugin/field_desc_proto_to_code.py
+++ b/protobuf_to_pydantic/plugin/field_desc_proto_to_code.py
@@ -77,15 +77,15 @@ class FileDescriptorProtoToCode(BaseP2C):
         for _index in range(min(len(fd_path_list), len(message_path_list))):
             if message_path_list[_index] == fd_path_list[_index]:
                 index = _index
+        # common/a/name.proto includes common/b/include.proto
+        # The basic name: include_p2p
+        module_name: str = message_path_list[-1].replace(".proto", "") + self.config.file_name_suffix
+        # Add non-shared parts: b.include_p2p
+        module_name = ".".join(message_path_list[index + 1 : -1] + (module_name,))
 
-        module_name: str = (
-            ".".join(message_path_list[index + 1 : -1])
-            + "."
-            + message_path_list[-1].replace(".proto", "")
-            + self.config.file_name_suffix
-        )
         logger.info((self._fd.name, other_fd.name, index))
         if index != -1:
+            # Add relative parts: ..b.include_p2p
             module_name = "." * (len(message_path_list) - (index + 1)) + module_name
         self._add_import_code(module_name, type_str)
 


### PR DESCRIPTION
The code had a bug that in case all folders were shared (=no path elements to add to the module name), the code ended up with a `.` in front of the name before adding relative dots and therefore had one dot too many.