### PR TITLE
Change generating import statement logic from relative path to absolute path

### DIFF
--- a/protobuf_to_pydantic/plugin/field_desc_proto_to_code.py
+++ b/protobuf_to_pydantic/plugin/field_desc_proto_to_code.py
@@ -100,22 +100,12 @@ class FileDescriptorProtoToCode(BaseP2C):
         if other_fd.name == self._fd.name:
             return
 
-        fd_path_list: Tuple[str, ...] = Path(self._fd.name).parts
         message_path_list: Tuple[str, ...] = Path(other_fd.name).parts
-        index: int = -1
-        for _index in range(min(len(fd_path_list), len(message_path_list))):
-            if message_path_list[_index] == fd_path_list[_index]:
-                index = _index
-        # common/a/name.proto includes common/b/include.proto
         # The basic name: include_p2p
         module_name: str = message_path_list[-1].replace(".proto", "") + self.config.file_name_suffix
-        # Add non-shared parts: b.include_p2p
-        module_name = ".".join(message_path_list[index + 1 : -1] + (module_name,))
+        module_name = ".".join(message_path_list[:-1] + (module_name,))
 
-        logger.info((self._fd.name, other_fd.name, index))
-        if index != -1:
-            # Add relative parts: ..b.include_p2p
-            module_name = "." * (len(message_path_list) - (index + 1)) + module_name
+        logger.info((self._fd.name, other_fd.name))
         self._add_import_code(module_name, type_str)
 
     def _comment_handler(self, leading_comments: str, trailing_comments: str) -> Tuple[dict, str, str]:


### PR DESCRIPTION
close #62 

The original logic had issues generating import statements in some cases where only the intermediate paths matched (for details, please see issue #62). Therefore, I have changed the approach to resolve imports from the root instead of using relative paths.