### PR TITLE
Change logic for generating import statement

### DIFF
--- a/protobuf_to_pydantic/plugin/field_desc_proto_to_code.py
+++ b/protobuf_to_pydantic/plugin/field_desc_proto_to_code.py
@@ -106,6 +106,8 @@ class FileDescriptorProtoToCode(BaseP2C):
         for _index in range(min(len(fd_path_list), len(message_path_list))):
             if message_path_list[_index] == fd_path_list[_index]:
                 index = _index
+            else:
+                break
         # common/a/name.proto includes common/b/include.proto
         # The basic name: include_p2p
         module_name: str = message_path_list[-1].replace(".proto", "") + self.config.file_name_suffix
@@ -113,9 +115,8 @@ class FileDescriptorProtoToCode(BaseP2C):
         module_name = ".".join(message_path_list[index + 1 : -1] + (module_name,))
 
         logger.info((self._fd.name, other_fd.name, index))
-        if index != -1:
-            # Add relative parts: ..b.include_p2p
-            module_name = "." * (len(message_path_list) - (index + 1)) + module_name
+        # Add relative parts: ..b.include_p2p
+        module_name = "." * (len(message_path_list) - (index + 1)) + module_name
         self._add_import_code(module_name, type_str)
 
     def _comment_handler(self, leading_comments: str, trailing_comments: str) -> Tuple[dict, str, str]:


### PR DESCRIPTION
close #62 

The original logic had issues generating import statements in some cases where only the intermediate paths matched (for details, please see issue #62). 

This PR contains two changes.
First, it fixes the relative import bug described in #62.
Second, it makes sure that imports are relative even when importing from the root. This helps with path resolution when importing generated code from the destination project.