### PR TITLE
Use stdlib tomllib module in python 3.11+

### DIFF
--- a/protobuf_to_pydantic/util.py
+++ b/protobuf_to_pydantic/util.py
@@ -128,16 +128,19 @@ def get_pyproject_content(pyproject_file_path: str) -> str:
 def format_content(content_str: str, pyproject_file_path: str = "") -> str:
     pyproject_dict: dict = {}
     try:
-        import toml  # type: ignore
+        import tomllib as toml
     except ImportError:
-        logging.warning(
-            "The toml module is not installed and the configuration information cannot be obtained through"
-            " pyproject.toml"
-        )
-    else:
-        pyproject_content = get_pyproject_content(pyproject_file_path)
-        if pyproject_content:
-            pyproject_dict = toml.loads(pyproject_content)
+        try:
+            import toml  # type: ignore
+        except ImportError:
+            logging.warning(
+                "The toml module is not installed and the configuration information cannot be obtained through"
+                " pyproject.toml"
+            )
+            return content_str
+    pyproject_content = get_pyproject_content(pyproject_file_path)
+    if pyproject_content:
+        pyproject_dict = toml.loads(pyproject_content)
     try:
         p2p_format_dict: dict = pyproject_dict["tool"]["protobuf-to-pydantic"]["format"]
     except KeyError:


### PR DESCRIPTION
Use stdlib `tomllib` module in python 3.11+

Fallback to `toml` pkg.