### PR TITLE
Fix the imports when common path diverges

### DIFF
--- a/protobuf_to_pydantic/plugin/field_desc_proto_to_code.py
+++ b/protobuf_to_pydantic/plugin/field_desc_proto_to_code.py
@@ -102,9 +102,13 @@ class FileDescriptorProtoToCode(BaseP2C):
         fd_path_list: Tuple[str, ...] = Path(self._fd.name).parts
         message_path_list: Tuple[str, ...] = Path(other_fd.name).parts
         index: int = -1
+        # find the index of the common path starting at root
         for _index in range(min(len(fd_path_list), len(message_path_list))):
             if message_path_list[_index] == fd_path_list[_index]:
                 index = _index
+            # break when the common path diverges
+            else:
+                break
         # common/a/name.proto includes common/b/include.proto
         # The basic name: include_p2p
         module_name: str = message_path_list[-1].replace(".proto", "") + self.config.file_name_suffix


### PR DESCRIPTION
A common protobuf directory pattern as described here -> https://buf.build/docs/best-practices/style-guide/ is to have version folders. 

This fix is needed to generate the correct imports. Otherwise files form different packages always start at the v1, v2 etc. level. 