### PR TITLE
Fix field names that conflict with Python built-in types

### DIFF
--- a/example/example_proto/demo/field_name_conflict.proto
+++ b/example/example_proto/demo/field_name_conflict.proto
@@ -1,0 +1,26 @@
+syntax = "proto3";
+package test_field_name_conflict;
+
+// Test message with field names that conflict with Python standard types
+message ConflictingFieldNames {
+  // Field name conflicts with Python built-in type 'bytes'
+  bytes bytes = 1;
+  
+  // Field name conflicts with Python built-in type 'str'
+  string str = 2;
+  
+  // Field name conflicts with Python built-in type 'int'
+  int32 int = 3;
+  
+  // Field name conflicts with Python built-in type 'float'
+  float float = 4;
+  
+  // Field name conflicts with Python built-in type 'bool'
+  bool bool = 5;
+  
+  // Field name conflicts with Python built-in type 'list'
+  repeated string list = 6;
+  
+  // Field name conflicts with Python built-in type 'dict'
+  map<string, string> dict = 7;
+}

--- a/tests/test_gen_code/test_field_name_conflicts.py
+++ b/tests/test_gen_code/test_field_name_conflicts.py
@@ -1,0 +1,101 @@
+"""Test for handling field names that conflict with Python built-in types."""
+from typing import Type
+
+from google.protobuf import __version__
+from pydantic import BaseModel
+
+from protobuf_to_pydantic import msg_to_pydantic_model, pydantic_model_to_py_code
+from protobuf_to_pydantic._pydantic_adapter import is_v1
+from protobuf_to_pydantic.gen_model import clear_create_model_cache
+from protobuf_to_pydantic.util import format_content
+
+# Import the generated protobuf message
+if __version__ > "4.0.0":
+    if is_v1:
+        from example.proto_pydanticv1.example.example_proto.demo import field_name_conflict_pb2
+    else:
+        from example.proto_pydanticv2.example.example_proto.demo import field_name_conflict_pb2  # type: ignore[no-redef]
+else:
+    if is_v1:
+        from example.proto_3_20_pydanticv1.example.example_proto.demo import field_name_conflict_pb2  # type: ignore[no-redef]
+    else:
+        from example.proto_3_20_pydanticv2.example.example_proto.demo import field_name_conflict_pb2  # type: ignore[no-redef]
+
+
+class TestFieldNameConflicts:
+    @staticmethod
+    def _model_output(msg) -> str:
+        """Generate model output for testing."""
+        clear_create_model_cache()
+        return pydantic_model_to_py_code(msg_to_pydantic_model(msg))
+
+    def test_builtin_field_names_renamed(self) -> None:
+        """Test that fields with names matching Python built-ins are renamed."""
+        # Expected output for fields that conflict with built-in types
+        if is_v1:
+            expected_content = """
+class ConflictingFieldNames(BaseModel):
+    bytes_: bytes = Field(default=b"", alias="bytes")
+    str_: str = Field(default="", alias="str")
+    int_: int = Field(default=0, alias="int")
+    float_: float = Field(default=0.0, alias="float")
+    bool_: bool = Field(default=False, alias="bool")
+    list_: typing.List[str] = Field(default_factory=list, alias="list")
+    dict_: typing.Dict[str, str] = Field(default_factory=dict, alias="dict")
+"""
+        else:
+            expected_content = """
+class ConflictingFieldNames(BaseModel):
+    bytes_: bytes = Field(default=b"", alias="bytes")
+    str_: str = Field(default="", alias="str")
+    int_: int = Field(default=0, alias="int")
+    float_: float = Field(default=0.0, alias="float")
+    bool_: bool = Field(default=False, alias="bool")
+    list_: typing.List[str] = Field(default_factory=list, alias="list")
+    dict_: typing.Dict[str, str] = Field(default_factory=dict, alias="dict")
+"""
+
+        output = self._model_output(field_name_conflict_pb2.ConflictingFieldNames)
+        assert format_content(expected_content) in output
+
+    def test_field_alias_functionality(self) -> None:
+        """Test that renamed fields work correctly with aliases."""
+        model: Type[BaseModel] = msg_to_pydantic_model(field_name_conflict_pb2.ConflictingFieldNames)
+
+        # Test that we can create instance using original field names
+        instance = model(
+            bytes=b"test",
+            str="hello",
+            int=42,
+            float=3.14,
+            bool=True,
+            list=["a", "b"],
+            dict={"key": "value"}
+        )
+
+        # Verify data can be accessed
+        data = instance.model_dump(by_alias=True) if hasattr(instance, 'model_dump') else instance.dict(by_alias=True)
+        assert data['bytes'] == b"test"
+        assert data['str'] == "hello"
+        assert data['int'] == 42
+        assert data['float'] == 3.14
+        assert data['bool'] is True
+        assert data['list'] == ["a", "b"]
+        assert data['dict'] == {"key": "value"}
+
+    def test_generated_code_validity(self) -> None:
+        """Test that generated code is valid Python."""
+        output = self._model_output(field_name_conflict_pb2.ConflictingFieldNames)
+
+        # Should not have problematic patterns like "bytes: bytes"
+        assert "bytes: bytes" not in output
+        assert "str: str" not in output
+        assert "int: int" not in output
+
+        # Should have safe patterns with underscore
+        assert "bytes_: bytes" in output
+        assert "str_: str" in output
+        assert "int_: int" in output
+
+        # Generated code should compile without errors
+        compile(output, '<string>', 'exec')


### PR DESCRIPTION
## Description

This PR fixes a bug where protobuf field names that overlap with Python built-in types (like `bytes`, `str`, `int`, etc.) cause issues in the generated Pydantic models.

## The Problem

When a protobuf message has fields with names like `bytes`, the generated Pydantic model creates code like:

```python
bytes: bytes = Field(default=b"")
```

This is problematic because the field name `bytes` shadows the built-in type `bytes`, which can cause syntax errors or unexpected behavior.

## The Solution

This PR implements a fix that:

1. Detects when a protobuf field name conflicts with Python reserved words or built-in types
2. Renames the field by adding an underscore suffix (e.g., `bytes` → `bytes_`)
3. Adds an `alias` parameter to maintain compatibility with the original protobuf field name

### Example

Given this protobuf message:
```protobuf
message ConflictingFieldNames {
  bytes bytes = 1;
  string str = 2;
  int32 int = 3;
}
```

The generated Pydantic model now produces:
```python
class ConflictingFieldNames(BaseModel):
    bytes_: bytes = Field(default=b"", alias="bytes")
    str_: str = Field(default="", alias="str")
    int_: int = Field(default=0, alias="int")
```

## Changes Made

1. **Added utility functions in `util.py`**:
   - `PYTHON_BUILTINS`: Set of Python built-in types and functions to avoid
   - `is_python_reserved_field_name()`: Checks if a field name conflicts
   - `get_safe_field_name()`: Returns a safe field name with underscore suffix if needed

2. **Updated `gen_model.py`**:
   - Modified field processing to use `get_safe_field_name()`
   - Added logic to set the `alias` on FieldInfo when a field name is changed

3. **Updated `plugin/field_desc_proto_to_code.py`**:
   - Modified plugin code generation to handle field name conflicts
   - Added alias generation in the Field() call when needed

## Testing

Added test in `tests/test_gen_code/test_field_name_conflicts.py` that verifies:
- Fields with conflicting names are renamed with underscore suffix
- Proper aliases are added to maintain protobuf compatibility
- Generated code is syntactically valid Python
- Models work correctly with the aliases

## Backward Compatibility

This change maintains full backward compatibility:
- Only fields with names that conflict with Python built-ins are affected
- The alias ensures protobuf wire format compatibility
- Existing code continues to work as before