### PR TITLE
Exclude pydantic 2.12

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ protoc-gen-protobuf-to-pydantic = "protobuf_to_pydantic.plugin.main:main"
 
 [tool.poetry.dependencies]
 python = "^3.7"
-pydantic = ">=1.9.2, <3.0.0, !=2.5.0, !=2.9.0, !=2.12"
+pydantic = ">=1.9.2, <3.0.0, !=2.5.0, !=2.9.0, !=2.12.*"
 protobuf = ">=3.20.3"
 
 toml = {version = "^0.10.2", optional = true}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ protoc-gen-protobuf-to-pydantic = "protobuf_to_pydantic.plugin.main:main"
 
 [tool.poetry.dependencies]
 python = "^3.7"
-pydantic = ">=1.9.2, <3.0.0, !=2.5.0, !=2.9.0"
+pydantic = ">=1.9.2, <3.0.0, !=2.5.0, !=2.9.0, !=2.12"
 protobuf = ">=3.20.3"
 
 toml = {version = "^0.10.2", optional = true}


### PR DESCRIPTION
Newly released pydantic 2.12 breaks compatibility with this library:
```
'pydantic_core._pydantic_core.ValidationInfo' object has no attribute 'template'
      Traceback (most recent call last):
        File "/Users/.../.cache/uv/builds-v0/.tmpDBckzd/lib/python3.12/site-packages/protobuf_to_pydantic/plugin/main.py", line 14, in main
          CodeGen(ConfigModel)
        File "/Users/.../.cache/uv/builds-v0/.tmpDBckzd/lib/python3.12/site-packages/protobuf_to_pydantic/plugin/code_gen.py", line 32, in __init__
          self.gen_config()
        File "/Users/.../.cache/uv/builds-v0/.tmpDBckzd/lib/python3.12/site-packages/protobuf_to_pydantic/plugin/code_gen.py", line 141, in gen_config
          self.config = self.config_class()
                        ^^^^^^^^^^^^^^^^^^^
        File "/Users/.../.cache/uv/builds-v0/.tmpDBckzd/lib/python3.12/site-packages/pydantic/main.py", line 250, in __init__
          validated_self = self.__pydantic_validator__.validate_python(data, self_instance=self)
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "/Users/.../.cache/uv/builds-v0/.tmpDBckzd/lib/python3.12/site-packages/protobuf_to_pydantic/plugin/config.py", line 117, in after_init
          values.template_instance = values.template(values.local_dict, values.comment_prefix)
                                     ^^^^^^^^^^^^^^^
      AttributeError: 'pydantic_core._pydantic_core.ValidationInfo' object has no attribute 'template'
```

This PR excludes 2.12 from the valid pydantic versions until a fix can be implemented