### PR TITLE
fix: handle package-scoped field options

### DIFF
--- a/example/example_proto/test_ignore/main_pkg.proto
+++ b/example/example_proto/test_ignore/main_pkg.proto
@@ -5,6 +5,7 @@ package test_ignore.main_pkg;
 import "example/example_proto/test_ignore/ignored_pkg.proto";
 
 message MainMessage {
+    // p2p: {"required": true}
     string normal_field = 1;
     // These types should be used but NOT imported due to ignore_pkg_list
     test_ignore.ignored_pkg.IgnoredMessage ignored_field = 2;

--- a/example/proto_3_20_pydanticv1/example/example_proto/test_ignore/main_pkg_p2p.py
+++ b/example/proto_3_20_pydanticv1/example/example_proto/test_ignore/main_pkg_p2p.py
@@ -10,7 +10,7 @@ class MainMessage(BaseModel):
     class Config:
         validate_all = True
 
-    normal_field: str = Field(default="")
+    normal_field: str = Field()
     # These types should be used but NOT imported due to ignore_pkg_list
     ignored_field: IgnoredMessage = Field(default_factory=IgnoredMessage)
     ignored_enum: IgnoredEnum = Field(default=0)

--- a/example/proto_3_20_pydanticv1/example/example_proto/test_ignore/main_pkg_pb2.pyi
+++ b/example/proto_3_20_pydanticv1/example/example_proto/test_ignore/main_pkg_pb2.pyi
@@ -17,6 +17,8 @@ class MainMessage(google.protobuf.message.Message):
     IGNORED_FIELD_FIELD_NUMBER: builtins.int
     IGNORED_ENUM_FIELD_NUMBER: builtins.int
     normal_field: typing.Text
+    """p2p: {"required": true}"""
+
     @property
     def ignored_field(self) -> example.example_proto.test_ignore.ignored_pkg_pb2.IgnoredMessage:
         """These types should be used but NOT imported due to ignore_pkg_list"""

--- a/example/proto_3_20_pydanticv2/example/example_proto/test_ignore/main_pkg_p2p.py
+++ b/example/proto_3_20_pydanticv2/example/example_proto/test_ignore/main_pkg_p2p.py
@@ -8,7 +8,7 @@ from pydantic import BaseModel, ConfigDict, Field
 
 class MainMessage(BaseModel):
     model_config = ConfigDict(validate_default=True)
-    normal_field: str = Field(default="")
+    normal_field: str = Field()
     # These types should be used but NOT imported due to ignore_pkg_list
     ignored_field: IgnoredMessage = Field(default_factory=IgnoredMessage)
     ignored_enum: IgnoredEnum = Field(default=0)

--- a/example/proto_3_20_pydanticv2/example/example_proto/test_ignore/main_pkg_pb2.pyi
+++ b/example/proto_3_20_pydanticv2/example/example_proto/test_ignore/main_pkg_pb2.pyi
@@ -17,6 +17,8 @@ class MainMessage(google.protobuf.message.Message):
     IGNORED_FIELD_FIELD_NUMBER: builtins.int
     IGNORED_ENUM_FIELD_NUMBER: builtins.int
     normal_field: typing.Text
+    """p2p: {"required": true}"""
+
     @property
     def ignored_field(self) -> example.example_proto.test_ignore.ignored_pkg_pb2.IgnoredMessage:
         """These types should be used but NOT imported due to ignore_pkg_list"""

--- a/example/proto_pydanticv1/example/example_proto/test_ignore/main_pkg_p2p.py
+++ b/example/proto_pydanticv1/example/example_proto/test_ignore/main_pkg_p2p.py
@@ -10,7 +10,7 @@ class MainMessage(BaseModel):
     class Config:
         validate_all = True
 
-    normal_field: str = Field(default="")
+    normal_field: str = Field()
     # These types should be used but NOT imported due to ignore_pkg_list
     ignored_field: IgnoredMessage = Field(default_factory=IgnoredMessage)
     ignored_enum: IgnoredEnum = Field(default=0)

--- a/example/proto_pydanticv1/example/example_proto/test_ignore/main_pkg_pb2.pyi
+++ b/example/proto_pydanticv1/example/example_proto/test_ignore/main_pkg_pb2.pyi
@@ -17,6 +17,8 @@ class MainMessage(google.protobuf.message.Message):
     IGNORED_FIELD_FIELD_NUMBER: builtins.int
     IGNORED_ENUM_FIELD_NUMBER: builtins.int
     normal_field: typing.Text
+    """p2p: {"required": true}"""
+
     @property
     def ignored_field(self) -> example.example_proto.test_ignore.ignored_pkg_pb2.IgnoredMessage:
         """These types should be used but NOT imported due to ignore_pkg_list"""

--- a/example/proto_pydanticv2/example/example_proto/test_ignore/main_pkg_p2p.py
+++ b/example/proto_pydanticv2/example/example_proto/test_ignore/main_pkg_p2p.py
@@ -8,7 +8,7 @@ from pydantic import BaseModel, ConfigDict, Field
 
 class MainMessage(BaseModel):
     model_config = ConfigDict(validate_default=True)
-    normal_field: str = Field(default="")
+    normal_field: str = Field()
     # These types should be used but NOT imported due to ignore_pkg_list
     ignored_field: IgnoredMessage = Field(default_factory=IgnoredMessage)
     ignored_enum: IgnoredEnum = Field(default=0)

--- a/example/proto_pydanticv2/example/example_proto/test_ignore/main_pkg_pb2.pyi
+++ b/example/proto_pydanticv2/example/example_proto/test_ignore/main_pkg_pb2.pyi
@@ -17,6 +17,8 @@ class MainMessage(google.protobuf.message.Message):
     IGNORED_FIELD_FIELD_NUMBER: builtins.int
     IGNORED_ENUM_FIELD_NUMBER: builtins.int
     normal_field: typing.Text
+    """p2p: {"required": true}"""
+
     @property
     def ignored_field(self) -> example.example_proto.test_ignore.ignored_pkg_pb2.IgnoredMessage:
         """These types should be used but NOT imported due to ignore_pkg_list"""

--- a/protobuf_to_pydantic/gen_model.py
+++ b/protobuf_to_pydantic/gen_model.py
@@ -213,8 +213,13 @@ class M2P(object):
     ###############
     # util method #
     ###############
-    def _get_field_info_dict_by_full_name(self, full_name: str) -> Optional["FieldInfoTypedDict"]:
-        split_full_name = full_name.split(".")
+    def _get_field_info_dict_by_full_name(
+        self, full_name: str, package_name: str = ""
+    ) -> Optional["FieldInfoTypedDict"]:
+        if package_name and full_name.startswith(f"{package_name}."):
+            split_full_name = full_name[len(package_name) + 1 :].split(".")
+        else:
+            split_full_name = full_name.split(".")
         if len(split_full_name) == 2:
             message_name, *key_list = split_full_name
         else:
@@ -340,7 +345,7 @@ class M2P(object):
     ####################
     # field  handler   #
     ####################
-    def _protobuf_field_type_is_type_message_handler(self, field_dataclass: FieldDataClass) -> None:
+    def _protobuf_field_type_is_type_message_handler(self, field_dataclass: FieldDataClass, package_name: str) -> None:
         protobuf_field = field_dataclass.protobuf_field
         if protobuf_field.message_type.name in self._message_type_dict_by_type_name:
             # Timestamp, Struct, Empty, Duration, Any support
@@ -377,7 +382,7 @@ class M2P(object):
         else:
             # support google.protobuf.Message
             field_info_dict: Union[FieldInfoTypedDict, dict] = (
-                self._get_field_info_dict_by_full_name(field_dataclass.protobuf_field.full_name) or {}
+                self._get_field_info_dict_by_full_name(field_dataclass.protobuf_field.full_name, package_name) or {}
             )
             skip_validate_rule = field_info_dict.get("skip", False)
             full_name = protobuf_field.message_type.full_name
@@ -480,9 +485,11 @@ class M2P(object):
             if field_dataclass.field_default is not _pydantic_adapter.PydanticUndefined:
                 field_dataclass.field_default = _pydantic_adapter.PydanticUndefined
 
-    def _gen_field_info(self, field_dataclass: FieldDataClass, skip_validate_rule: bool) -> Optional[FieldInfo]:
+    def _gen_field_info(
+        self, field_dataclass: FieldDataClass, skip_validate_rule: bool, package_name: str
+    ) -> Optional[FieldInfo]:
         field_class = self._default_field
-        field_info_dict = self._get_field_info_dict_by_full_name(field_dataclass.protobuf_field.full_name)
+        field_info_dict = self._get_field_info_dict_by_full_name(field_dataclass.protobuf_field.full_name, package_name)
 
         if field_info_dict is not None and not skip_validate_rule:
             if self._parse_msg_desc_method != "PGV":
@@ -595,6 +602,7 @@ class M2P(object):
     ) -> Type[BaseModel]:
         is_same_pkg = descriptor.file.name == root_descriptor.file.name if root_descriptor else True
         class_name = class_name or descriptor.name
+        package_name = descriptor.file.package or ""  # type: ignore
 
         if not is_same_pkg:
             class_name = replace_file_name_to_class_name(descriptor.file.name) + class_name
@@ -628,7 +636,7 @@ class M2P(object):
                 validators=validators,
             )
             if protobuf_field.type == FieldDescriptor.TYPE_MESSAGE:
-                self._protobuf_field_type_is_type_message_handler(field_dataclass)
+                self._protobuf_field_type_is_type_message_handler(field_dataclass, package_name)
             elif protobuf_field.type == FieldDescriptor.TYPE_ENUM:
                 self._protobuf_field_type_is_type_enum_handler(field_dataclass)
                 if _pydantic_adapter.is_v1:
@@ -641,7 +649,7 @@ class M2P(object):
             # At this time, the field type may be modified by the above logic, so it needs to be handled separately
             if protobuf_field.label == FieldDescriptor.LABEL_REPEATED:
                 self._protobuf_field_lable_is_label_repeated_handler(field_dataclass)
-            field_info = self._gen_field_info(field_dataclass, skip_validate_rule)
+            field_info = self._gen_field_info(field_dataclass, skip_validate_rule, package_name)
             if not field_info:
                 continue
 

--- a/protobuf_to_pydantic/get_message_option/from_message_option/base.py
+++ b/protobuf_to_pydantic/get_message_option/from_message_option/base.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Dict, Set, Type
+from typing import Dict, Set, Tuple, Type
 
 from protobuf_to_pydantic.constant import protobuf_common_type_dict
 from protobuf_to_pydantic.field_info_rule.protobuf_option_to_field_info.desc import gen_field_info_dict_from_field_desc
@@ -8,7 +8,7 @@ from protobuf_to_pydantic.grpc_types import Descriptor, FieldDescriptor, Message
 
 _logger: logging.Logger = logging.getLogger(__name__)
 
-_global_message_option_dict: Dict[str, Dict[str, MessageOptionTypedDict]] = {}
+_global_message_option_dict: Dict[Tuple[str, str, str], Dict[str, MessageOptionTypedDict]] = {}
 
 
 class ParseFromPbOption(object):
@@ -17,10 +17,12 @@ class ParseFromPbOption(object):
     def __init__(self, message: Type[Message]):
         self.message = message
         self._message_option_dict: Dict[str, MessageOptionTypedDict] = {}
-        if self.protobuf_pkg not in _global_message_option_dict:
-            _global_message_option_dict[self.protobuf_pkg] = self._message_option_dict
+        descriptor: Descriptor = message.DESCRIPTOR
+        cache_key = (self.protobuf_pkg, descriptor.file.package or "", descriptor.file.name)
+        if cache_key not in _global_message_option_dict:
+            _global_message_option_dict[cache_key] = self._message_option_dict
         else:
-            self._message_option_dict = _global_message_option_dict[self.protobuf_pkg]
+            self._message_option_dict = _global_message_option_dict[cache_key]
 
     def parse(self) -> Dict[str, MessageOptionTypedDict]:
         descriptor: Descriptor = self.message.DESCRIPTOR

--- a/tests/test_validate_in_runtime/test_gen_model_validate_in_runtime/test_package_resolution.py
+++ b/tests/test_validate_in_runtime/test_gen_model_validate_in_runtime/test_package_resolution.py
@@ -1,0 +1,61 @@
+from importlib import import_module
+from typing import Any, Generator, cast
+
+import pytest
+from google.protobuf import __version__
+from pydantic import ValidationError
+
+from protobuf_to_pydantic import msg_to_pydantic_model
+from protobuf_to_pydantic._pydantic_adapter import is_v1
+from protobuf_to_pydantic.gen_model import clear_create_model_cache
+from protobuf_to_pydantic.get_message_option.from_message_option import base as message_option_base
+from tests.base.base_p2p_validate import local_dict
+
+if __version__ > "4.0.0":
+    proto_module = "example.proto_pydanticv1" if is_v1 else "example.proto_pydanticv2"
+else:
+    proto_module = "example.proto_3_20_pydanticv1" if is_v1 else "example.proto_3_20_pydanticv2"
+
+all_feidl_set_optional_demo_pb2 = cast(
+    Any,
+    import_module(f"{proto_module}.example.example_proto.demo.all_feidl_set_optional_demo_pb2"),
+)
+p2p_demo_pb2 = cast(
+    Any,
+    import_module(f"{proto_module}.example.example_proto.p2p_validate.demo_pb2"),
+)
+main_pkg_pb2 = cast(
+    Any,
+    import_module(f"{proto_module}.example.example_proto.test_ignore.main_pkg_pb2"),
+)
+
+
+@pytest.fixture(autouse=True)
+def clear_runtime_generation_caches() -> Generator[None, None, None]:
+    clear_create_model_cache()
+    message_option_base._global_message_option_dict.clear()
+    yield
+    clear_create_model_cache()
+    message_option_base._global_message_option_dict.clear()
+
+
+def test_proto_file_comments_resolve_fields_with_multi_part_package_name() -> None:
+    model = msg_to_pydantic_model(main_pkg_pb2.MainMessage, parse_msg_desc_method=".")
+
+    with pytest.raises(ValidationError):
+        model()
+
+    model(normal_field="normal")
+
+
+def test_p2p_message_option_cache_is_isolated_by_proto_package() -> None:
+    msg_to_pydantic_model(
+        all_feidl_set_optional_demo_pb2.OptionalMessage,
+        local_dict=local_dict,
+        all_field_set_optional=True,
+    )
+
+    model = msg_to_pydantic_model(p2p_demo_pb2.OptionalMessage, local_dict=local_dict)
+
+    with pytest.raises(ValidationError):
+        model()


### PR DESCRIPTION
Resolve field option lookups by stripping the full proto package prefix before reading message/field path segments.

Partition parsed protobuf option caches by extension package, proto package, and file name so same-named messages in different packages cannot reuse stale options.

Add regression coverage for multi-part package comment rules and P2P option cache collisions.